### PR TITLE
Add Piper neural TTS backend and wire site for high-quality cast audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,21 @@ Weekly original political satire episode transcripts.
 
 ---
 
-## Episode audio (FOSS, on-the-fly)
+## Episode audio (FOSS)
 
-The site now generates episode audio in-browser on demand using the FOSS `meSpeak.js` engine.
+### Default (browser local)
+The site generates episode audio in-browser on demand (no committed audio binaries).
 
-- No pre-rendered audio files are committed to the repo.
-- Open an episode and click **Generate audio** to create local playback.
-- Voice target is a gruff British satire narrator style (not an impersonation of any real actor/person).
+- Open an episode and click **Generate audio**.
+- Character separation is applied where local browser voices allow it.
+
+### High-quality mode (neural cast voices)
+For better quality, run the included Piper TTS server and pass `ttsApi` in the site URL:
+
+- `https://oc-dev-snf.github.io/cabinet-chaos-episodes/?ttsApi=https://YOUR-TTS-HOST`
+
+When configured, the frontend uses neural server audio first, then falls back to browser voices.
+See `tts-server/README.md` for setup.
 
 ---
 

--- a/tts-server/.gitignore
+++ b/tts-server/.gitignore
@@ -1,0 +1,4 @@
+
+# Python cache
+__pycache__/
+*.pyc

--- a/tts-server/Dockerfile
+++ b/tts-server/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg ca-certificates curl \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install piper binary (packaged build expected in PATH as "piper")
+RUN curl -L -o /tmp/piper.tar.gz https://github.com/rhasspy/piper/releases/download/v1.2.0/piper_linux_x86_64.tar.gz \
+  && mkdir -p /opt/piper \
+  && tar -xzf /tmp/piper.tar.gz -C /opt/piper --strip-components=1 \
+  && ln -s /opt/piper/piper /usr/local/bin/piper \
+  && rm /tmp/piper.tar.gz
+
+COPY app.py /app/app.py
+
+EXPOSE 8000
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tts-server/README.md
+++ b/tts-server/README.md
@@ -1,0 +1,51 @@
+# Neural TTS server (Piper)
+
+This service provides per-character neural TTS for the Cabinet Chaos web app.
+
+## API
+
+- `GET /health`
+- `POST /v1/speak`
+
+`POST /v1/speak` body:
+
+```json
+{
+  "episode": "2026-03-28-episode-042...",
+  "title": "Tom, Torque & Gochujang",
+  "format": "mp3",
+  "segments": [
+    {"type": "dialogue", "speaker": "CALLUM", "text": "..."},
+    {"type": "scene", "text": "OPEN PLAN OFFICE"}
+  ]
+}
+```
+
+## Run locally
+
+1. Install Piper + ffmpeg and download voice models.
+2. Set model env vars (you can map multiple roles to one model initially):
+
+```bash
+export PIPER_MODEL_CALLUM=models/en_GB-alan-medium.onnx
+export PIPER_MODEL_TOM=models/en_GB-alan-medium.onnx
+export PIPER_MODEL_MARS=models/en_GB-cori-high.onnx
+export PIPER_MODEL_ANALYST=models/en_GB-cori-high.onnx
+export PIPER_MODEL_NARRATOR=models/en_GB-alan-medium.onnx
+export PIPER_MODEL_SCENE=models/en_GB-cori-high.onnx
+```
+
+3. Start server:
+
+```bash
+pip install -r requirements.txt
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+## Wire into web app
+
+Use query param:
+
+- `https://oc-dev-snf.github.io/cabinet-chaos-episodes/?ttsApi=https://YOUR-TTS-HOST`
+
+When configured, the frontend prefers this neural endpoint first, then falls back to browser/system voices.

--- a/tts-server/app.py
+++ b/tts-server/app.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Literal
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field
+
+
+PIPER_BIN = os.getenv("PIPER_BIN", "piper")
+FFMPEG_BIN = os.getenv("FFMPEG_BIN", "ffmpeg")
+CACHE_DIR = Path(os.getenv("TTS_CACHE_DIR", "/tmp/cabinet-chaos-tts-cache"))
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Configure model paths via env. You can point multiple roles to the same model to start.
+VOICE_MODEL_MAP = {
+    "CALLUM": os.getenv("PIPER_MODEL_CALLUM", "models/en_GB-alan-medium.onnx"),
+    "TOM": os.getenv("PIPER_MODEL_TOM", "models/en_GB-alan-medium.onnx"),
+    "MARS": os.getenv("PIPER_MODEL_MARS", "models/en_GB-cori-high.onnx"),
+    "ANALYST": os.getenv("PIPER_MODEL_ANALYST", "models/en_GB-cori-high.onnx"),
+    "NARRATOR": os.getenv("PIPER_MODEL_NARRATOR", "models/en_GB-alan-medium.onnx"),
+    "SCENE": os.getenv("PIPER_MODEL_SCENE", "models/en_GB-cori-high.onnx"),
+}
+
+
+class Segment(BaseModel):
+    type: Literal["dialogue", "scene", "narration"]
+    text: str = Field(min_length=1)
+    speaker: str | None = None
+
+
+class SpeakRequest(BaseModel):
+    episode: str
+    title: str = ""
+    segments: list[Segment]
+    format: Literal["mp3", "wav"] = "mp3"
+
+
+app = FastAPI(title="Cabinet Chaos Neural TTS API", version="1.0.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def model_for_segment(seg: Segment) -> str:
+    if seg.type == "scene":
+        return VOICE_MODEL_MAP["SCENE"]
+    if seg.type == "dialogue" and seg.speaker:
+        return VOICE_MODEL_MAP.get(seg.speaker.upper(), VOICE_MODEL_MAP["NARRATOR"])
+    return VOICE_MODEL_MAP["NARRATOR"]
+
+
+def run_checked(cmd: list[str]):
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError((proc.stderr or proc.stdout or "command failed").strip())
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+@app.post("/v1/speak")
+def speak(req: SpeakRequest):
+    if not req.segments:
+        raise HTTPException(status_code=400, detail="segments required")
+
+    cache_key = hashlib.sha256(
+        json.dumps(req.model_dump(), sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+    ext = "mp3" if req.format == "mp3" else "wav"
+    out_file = CACHE_DIR / f"{cache_key}.{ext}"
+    if out_file.exists():
+        return FileResponse(path=str(out_file), media_type=f"audio/{ext}", filename=out_file.name)
+
+    with tempfile.TemporaryDirectory(prefix="cabinet-chaos-tts-") as td:
+        tdp = Path(td)
+        wav_parts: list[Path] = []
+
+        for i, seg in enumerate(req.segments):
+            model = model_for_segment(seg)
+            in_txt = tdp / f"seg-{i:04d}.txt"
+            out_wav = tdp / f"seg-{i:04d}.wav"
+            in_txt.write_text(seg.text.strip(), encoding="utf-8")
+
+            cmd = [PIPER_BIN, "--model", model, "--output_file", str(out_wav), "--input_file", str(in_txt)]
+            try:
+                run_checked(cmd)
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=f"piper failed for segment {i}: {e}")
+
+            wav_parts.append(out_wav)
+
+        list_file = tdp / "concat.txt"
+        list_file.write_text("\n".join([f"file '{p.as_posix()}'" for p in wav_parts]), encoding="utf-8")
+        merged_wav = tdp / "merged.wav"
+
+        try:
+            run_checked([
+                FFMPEG_BIN,
+                "-y",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(list_file),
+                "-c",
+                "copy",
+                str(merged_wav),
+            ])
+        except Exception:
+            # fallback to re-encode concat if stream copy fails
+            run_checked([
+                FFMPEG_BIN,
+                "-y",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(list_file),
+                str(merged_wav),
+            ])
+
+        if req.format == "wav":
+            shutil.copy2(merged_wav, out_file)
+        else:
+            run_checked([
+                FFMPEG_BIN,
+                "-y",
+                "-i",
+                str(merged_wav),
+                "-codec:a",
+                "libmp3lame",
+                "-q:a",
+                "4",
+                str(out_file),
+            ])
+
+    return FileResponse(path=str(out_file), media_type=f"audio/{ext}", filename=out_file.name)

--- a/tts-server/requirements.txt
+++ b/tts-server/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.116.1
+uvicorn[standard]==0.35.0
+pydantic==2.11.7

--- a/web/app.js
+++ b/web/app.js
@@ -35,9 +35,17 @@ const episodeAudioEl = document.getElementById('episode-audio');
 const audioStatusEl = document.getElementById('audio-status');
 const audioGenerateEl = document.getElementById('audio-generate');
 
+const remoteTtsApiBase = (() => {
+  const fromQuery = new URLSearchParams(window.location.search).get('ttsApi');
+  if (fromQuery) return fromQuery.replace(/\/$/, '');
+  if (window.CABINET_TTS_API) return String(window.CABINET_TTS_API).replace(/\/$/, '');
+  return '';
+})();
+
 let currentMarkdown = '';
 let currentEpisodeTitle = '';
 let currentEpisodePath = '';
+let currentRemoteAudioUrl = null;
 let chaosLevel = Number.parseInt(localStorage.getItem('cabinetChaos.chaos') || '6', 10);
 let ambientPanicEnabled = (localStorage.getItem('cabinetChaos.ambient') || 'off') === 'on';
 let foiModeEnabled = (localStorage.getItem('cabinetChaos.foiMode') || 'off') === 'on';
@@ -586,6 +594,50 @@ function speakWithWebSpeechNatural(md) {
   return true;
 }
 
+async function tryRemoteNeuralTts(md) {
+  if (!remoteTtsApiBase || !episodeAudioEl || !audioStatusEl) return false;
+
+  const segments = markdownToSpeechSegments(md).map((s) => ({
+    type: s.type,
+    speaker: s.speaker || null,
+    text: s.text,
+  }));
+
+  if (!segments.length) return false;
+
+  try {
+    audioStatusEl.textContent = 'Generating neural audio…';
+    const res = await fetch(`${remoteTtsApiBase}/v1/speak`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        episode: currentEpisodePath || 'unknown',
+        title: currentEpisodeTitle || '',
+        segments,
+        format: 'mp3',
+      }),
+    });
+
+    if (!res.ok) throw new Error(`Remote TTS HTTP ${res.status}`);
+    const blob = await res.blob();
+
+    if (currentRemoteAudioUrl) {
+      URL.revokeObjectURL(currentRemoteAudioUrl);
+      currentRemoteAudioUrl = null;
+    }
+
+    currentRemoteAudioUrl = URL.createObjectURL(blob);
+    episodeAudioEl.hidden = false;
+    episodeAudioEl.src = currentRemoteAudioUrl;
+    episodeAudioEl.load();
+    await episodeAudioEl.play();
+    audioStatusEl.textContent = 'Playing neural cast audio.';
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function generateEpisodeAudio() {
   if (!audioWrapEl || !episodeAudioEl || !audioStatusEl) return;
   if (!currentMarkdown) {
@@ -595,7 +647,12 @@ async function generateEpisodeAudio() {
 
   audioStatusEl.textContent = 'Generating audio…';
 
-  // Preferred path: more natural browser voices with per-line prosody.
+  // Preferred path: server-side neural cast synthesis (Piper API).
+  if (await tryRemoteNeuralTts(currentMarkdown)) {
+    return;
+  }
+
+  // Fallback path: natural browser voices with per-line prosody.
   if (speakWithWebSpeechNatural(currentMarkdown)) {
     return;
   }
@@ -642,6 +699,10 @@ function updateEpisodeAudio() {
   if (!audioWrapEl || !episodeAudioEl || !audioStatusEl) return;
   audioWrapEl.hidden = false;
   episodeAudioEl.hidden = true;
+  if (currentRemoteAudioUrl) {
+    URL.revokeObjectURL(currentRemoteAudioUrl);
+    currentRemoteAudioUrl = null;
+  }
   episodeAudioEl.removeAttribute('src');
   episodeAudioEl.load();
   if (currentSpeechId !== null && window.meSpeak) {


### PR DESCRIPTION
## Summary
Implement a real neural FOSS TTS path (Piper backend) with per-character cast synthesis, and wire the site to use it.

## Changes
- Add `tts-server/` FastAPI service that:
  - accepts segmented script input (`dialogue`/`scene`/`narration`)
  - maps speakers to configurable Piper models
  - synthesizes per segment and concatenates audio
  - returns MP3/WAV with cache-by-request hash
- Add Dockerfile + requirements + setup docs for the TTS server.
- Update frontend (`web/app.js`) to prefer remote neural endpoint (`?ttsApi=...`) before browser fallback voices.
- Update README with high-quality neural mode setup.

## Why
Browser-only synthesis quality is too robotic. Neural backend synthesis gives materially better speech quality and clearer multi-character differentiation while staying FOSS.

## Validation
- `node --check web/app.js`
- `python3 -m py_compile tts-server/app.py`
- Frontend code-path review: remote neural first, browser fallback second.
